### PR TITLE
Refactoring QED.jl

### DIFF
--- a/.github/workflows/BuildDelopyDoc.yml
+++ b/.github/workflows/BuildDelopyDoc.yml
@@ -25,8 +25,8 @@ jobs:
           julia --project=docs/ -e 'import Pkg; Pkg.Registry.add(Pkg.RegistrySpec(url="https://github.com/JuliaRegistries/General"));'
       - name: Install dependencies
         run: |
-          julia --project=docs/ -e 'using Pkg; Pkg.develop(PackageSpec(path=pwd())); Pkg.instantiate()'
           julia --project=docs/ use_QEDprocesses_dev.jl
+          julia --project=docs/ -e 'using Pkg; Pkg.develop(PackageSpec(path=pwd())); Pkg.instantiate()'
       - name: Build and deploy
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} # If authenticating with GitHub Actions token

--- a/.github/workflows/BuildDelopyDoc.yml
+++ b/.github/workflows/BuildDelopyDoc.yml
@@ -25,7 +25,7 @@ jobs:
           julia --project=docs/ -e 'import Pkg; Pkg.Registry.add(Pkg.RegistrySpec(url="https://github.com/JuliaRegistries/General"));'
       - name: Install dependencies
         run: |
-          julia --project=docs/ use_QEDprocesses_dev.jl
+          julia --project=docs/ add_QEDcore_dev.jl
           julia --project=docs/ -e 'using Pkg; Pkg.develop(PackageSpec(path=pwd())); Pkg.instantiate()'
       - name: Build and deploy
         env:

--- a/.github/workflows/BuildDelopyDoc.yml
+++ b/.github/workflows/BuildDelopyDoc.yml
@@ -5,7 +5,7 @@ on:
     branches:
       - master
       - dev
-    tags: '*'
+    tags: "*"
   pull_request:
 
 jobs:
@@ -18,13 +18,15 @@ jobs:
       - uses: actions/checkout@v4
       - uses: julia-actions/setup-julia@v1
         with:
-          version: '1.9'
-      - name: Add custom registry 
+          version: "1.9"
+      - name: Add custom registry
         run: |
           julia --project=docs/ -e 'import Pkg; Pkg.Registry.add(Pkg.RegistrySpec(url="https://github.com/QEDjl-project/registry.git"));'
           julia --project=docs/ -e 'import Pkg; Pkg.Registry.add(Pkg.RegistrySpec(url="https://github.com/JuliaRegistries/General"));'
       - name: Install dependencies
-        run: julia --project=docs/ -e 'using Pkg; Pkg.develop(PackageSpec(path=pwd())); Pkg.instantiate()'
+        run: |
+          julia --project=docs/ -e 'using Pkg; Pkg.develop(PackageSpec(path=pwd())); Pkg.instantiate()'
+          julia --project=docs/ use_QEDprocesses_dev.jl
       - name: Build and deploy
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} # If authenticating with GitHub Actions token

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -11,7 +11,7 @@ stages:
     - git clone --depth 1 -b dev https://github.com/QEDjl-project/QED.jl.git /QEDjl
     - julia --project=. -e 'import Pkg; Pkg.Registry.add(Pkg.RegistrySpec(url="https://github.com/QEDjl-project/registry.git"));'
     - julia --project=. -e 'import Pkg; Pkg.Registry.add(Pkg.RegistrySpec(url="https://github.com/JuliaRegistries/General"));'
-    - julia --project=. use_QEDprocesses_dev.jl
+    - julia --project=. add_QEDcore_dev.jl
     - >
       if [[ $CI_COMMIT_BRANCH == "main" || $CI_COMMIT_REF_NAME == "main" || $CI_COMMIT_BRANCH == "dev" || $CI_COMMIT_REF_NAME == "dev" ]]; then
         # set name of the commit message from CI_COMMIT_MESSAGE to NO_MESSAGE, that the script does not read accidentally custom packages from the commit message of a merge commit

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -11,6 +11,7 @@ stages:
     - git clone --depth 1 -b dev https://github.com/QEDjl-project/QED.jl.git /QEDjl
     - julia --project=. -e 'import Pkg; Pkg.Registry.add(Pkg.RegistrySpec(url="https://github.com/QEDjl-project/registry.git"));'
     - julia --project=. -e 'import Pkg; Pkg.Registry.add(Pkg.RegistrySpec(url="https://github.com/JuliaRegistries/General"));'
+    - julia --project=. use_QEDprocesses_dev.jl
     - >
       if [[ $CI_COMMIT_BRANCH == "main" || $CI_COMMIT_REF_NAME == "main" || $CI_COMMIT_BRANCH == "dev" || $CI_COMMIT_REF_NAME == "dev" ]]; then
         # set name of the commit message from CI_COMMIT_MESSAGE to NO_MESSAGE, that the script does not read accidentally custom packages from the commit message of a merge commit

--- a/Project.toml
+++ b/Project.toml
@@ -6,6 +6,7 @@ version = "0.1.0-dev"
 [deps]
 IntervalSets = "8197267c-284f-5f27-9208-e0e47529a953"
 QEDbase = "10e22c08-3ccb-4172-bfcf-7d7aa3d04d93"
+QEDcore = "35dc0263-cb5f-4c33-a114-1d7f54ab753e"
 QuadGK = "1fd47b50-473d-5c70-9696-f719f8f3bcdc"
 
 [compat]

--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,12 @@
 name = "QEDfields"
 uuid = "ac3a6c97-e859-4b9f-96bb-63d2a216042c"
-authors = ["Uwe Hernandez Acosta <u.hernandez@hzdr.de>", "Simeon Ehrig", "Klaus Steiniger", "Tom Jungnickel", "Anton Reinhard"]
+authors = [
+    "Uwe Hernandez Acosta <u.hernandez@hzdr.de>",
+    "Simeon Ehrig",
+    "Klaus Steiniger",
+    "Tom Jungnickel",
+    "Anton Reinhard",
+]
 version = "0.1.0-dev"
 
 [deps]
@@ -14,3 +20,12 @@ IntervalSets = "0.7"
 QEDbase = "0.1.5"
 QuadGK = "2"
 julia = "1.6"
+
+[extras]
+Pkg = "44cfe95a-1eb2-52ea-b672-e2afdf69b78f"
+Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
+SafeTestsets = "1bc83da4-3b8d-516f-aca4-4fe02f6d838f"
+Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
+
+[targets]
+test = ["Pkg", "Random", "SafeTestsets", "Test"]

--- a/add_QEDcore_dev.jl
+++ b/add_QEDcore_dev.jl
@@ -1,0 +1,5 @@
+
+@warn "This repository depends on the dev branch of QEDcore.jl\n It is NOT ready for release!"
+
+using Pkg: Pkg
+Pkg.add(; url="https://github.com/QEDjl-project/QEDcore.jl", rev="dev")

--- a/src/QEDfields.jl
+++ b/src/QEDfields.jl
@@ -1,6 +1,7 @@
 module QEDfields
 
 using QEDbase
+using QEDcore
 
 using IntervalSets
 using QuadGK

--- a/src/QEDfields.jl
+++ b/src/QEDfields.jl
@@ -1,6 +1,6 @@
 module QEDfields
 
-import QEDbase
+using QEDbase: QEDbase
 using QEDcore
 
 using IntervalSets

--- a/src/QEDfields.jl
+++ b/src/QEDfields.jl
@@ -1,6 +1,6 @@
 module QEDfields
 
-using QEDbase
+import QEDbase
 using QEDcore
 
 using IntervalSets

--- a/src/interfaces/background_field_interface.jl
+++ b/src/interfaces/background_field_interface.jl
@@ -113,7 +113,9 @@ end
 # amplitude functions
 
 function _amplitude(
-    field::AbstractPulsedPlaneWaveField, pol::QEDbase.AbstractDefinitePolarization, phi::Real
+    field::AbstractPulsedPlaneWaveField,
+    pol::QEDbase.AbstractDefinitePolarization,
+    phi::Real,
 )
     return oscillator(pol, phi) * _envelope(field, phi)
 end
@@ -148,7 +150,9 @@ Returns the value of the amplitude for a given polarization direction and phase 
     the value of the amplitude is returned, and zero otherwise.
 """
 function amplitude(
-    field::AbstractPulsedPlaneWaveField, pol::QEDbase.AbstractDefinitePolarization, phi::Real
+    field::AbstractPulsedPlaneWaveField,
+    pol::QEDbase.AbstractDefinitePolarization,
+    phi::Real,
 )
     return phi in domain(field) ? _amplitude(field, pol, phi) : zero(phi)
 end
@@ -187,7 +191,9 @@ Return the generic spectrum of the given field, for the given polarization direc
     where ``g(\\phi)`` is the [`envelope`](@ref) and ``l`` the photon number parameter.
 """
 function generic_spectrum(
-    field::AbstractPulsedPlaneWaveField, pol::QEDbase.AbstractDefinitePolarization, pnum::Real
+    field::AbstractPulsedPlaneWaveField,
+    pol::QEDbase.AbstractDefinitePolarization,
+    pnum::Real,
 )
     return _fourier_transform(t -> _amplitude(field, pol, t), domain(field), pnum)
 end

--- a/src/interfaces/background_field_interface.jl
+++ b/src/interfaces/background_field_interface.jl
@@ -113,14 +113,14 @@ end
 # amplitude functions
 
 function _amplitude(
-    field::AbstractPulsedPlaneWaveField, pol::AbstractDefinitePolarization, phi::Real
+    field::AbstractPulsedPlaneWaveField, pol::QEDbase.AbstractDefinitePolarization, phi::Real
 )
     return oscillator(pol, phi) * _envelope(field, phi)
 end
 
 function _amplitude(
     field::AbstractPulsedPlaneWaveField,
-    pol::AbstractDefinitePolarization,
+    pol::QEDbase.AbstractDefinitePolarization,
     phi::AbstractVector{T},
 ) where {T<:Real}
     # TODO: maybe use broadcasting here 
@@ -148,14 +148,14 @@ Returns the value of the amplitude for a given polarization direction and phase 
     the value of the amplitude is returned, and zero otherwise.
 """
 function amplitude(
-    field::AbstractPulsedPlaneWaveField, pol::AbstractDefinitePolarization, phi::Real
+    field::AbstractPulsedPlaneWaveField, pol::QEDbase.AbstractDefinitePolarization, phi::Real
 )
     return phi in domain(field) ? _amplitude(field, pol, phi) : zero(phi)
 end
 
 function amplitude(
     field::AbstractPulsedPlaneWaveField,
-    pol::AbstractDefinitePolarization,
+    pol::QEDbase.AbstractDefinitePolarization,
     phi::AbstractVector{T},
 ) where {T<:Real}
     # TODO: maybe use broadcasting here 
@@ -187,14 +187,14 @@ Return the generic spectrum of the given field, for the given polarization direc
     where ``g(\\phi)`` is the [`envelope`](@ref) and ``l`` the photon number parameter.
 """
 function generic_spectrum(
-    field::AbstractPulsedPlaneWaveField, pol::AbstractDefinitePolarization, pnum::Real
+    field::AbstractPulsedPlaneWaveField, pol::QEDbase.AbstractDefinitePolarization, pnum::Real
 )
     return _fourier_transform(t -> _amplitude(field, pol, t), domain(field), pnum)
 end
 
 function generic_spectrum(
     field::AbstractPulsedPlaneWaveField,
-    pol::AbstractDefinitePolarization,
+    pol::QEDbase.AbstractDefinitePolarization,
     photon_number_parameter::AbstractVector{T},
 ) where {T<:Real}
     # TODO: maybe use broadcasting here 

--- a/src/polarization.jl
+++ b/src/polarization.jl
@@ -18,11 +18,11 @@ where as for an indefinite polarization, a tuple of polarization vectors is retu
 
 !!! note "Convention"
 
-    In the current implementation, we use the `base_state` function for `Photon` provided by `QEDbase`.
+    In the current implementation, we use the `base_state` function for `Photon` provided by `QEDcore.jl`.
 
 """
-@inline function polarization_vector(pol::AbstractPolarization, mom)
-    return base_state(Photon(), Incoming(), mom, pol)
+@inline function polarization_vector(pol::QEDbase.AbstractPolarization, mom)
+    return QEDbase.base_state(QEDbase.Photon(), QEDbase.Incoming(), mom, pol)
 end
 
 """
@@ -44,9 +44,9 @@ Return the value of the base oscillator associated with a given polarization `po
 """
 function oscillator end
 
-@inline oscillator(::PolX, phi) = cos(phi)
-@inline oscillator(::PolY, phi) = sin(phi)
-@inline function oscillator(::AbstractIndefinitePolarization, phi)
+@inline oscillator(::QEDbase.PolX, phi) = cos(phi)
+@inline oscillator(::QEDbase.PolY, phi) = sin(phi)
+@inline function oscillator(::QEDbase.AbstractIndefinitePolarization, phi)
     sincos_res = sincos(phi)
     @inbounds cossin_res = (sincos_res[2], sincos_res[1])
     return cossin_res

--- a/src/pulses/cos_square.jl
+++ b/src/pulses/cos_square.jl
@@ -57,12 +57,12 @@ end
     return sig * _gsinc(sig * l / pi)
 end
 
-function generic_spectrum(field::CosSquarePulse, pol::PolX, pnum::Real)
+function generic_spectrum(field::CosSquarePulse, pol::QEDbase.PolX, pnum::Real)
     dphi = field.pulse_length
     return 0.5 * (_generic_FT(pnum + 1, dphi) + _generic_FT(pnum - 1, dphi))
 end
 
-function generic_spectrum(field::CosSquarePulse, pol::PolY, pnum::Real)
+function generic_spectrum(field::CosSquarePulse, pol::QEDbase.PolY, pnum::Real)
     dphi = field.pulse_length
     return -0.5im * (_generic_FT(pnum + 1, dphi) - _generic_FT(pnum - 1, dphi))
 end

--- a/test/Project.toml
+++ b/test/Project.toml
@@ -1,8 +1,0 @@
-[deps]
-IntervalSets = "8197267c-284f-5f27-9208-e0e47529a953"
-Pkg = "44cfe95a-1eb2-52ea-b672-e2afdf69b78f"
-QEDbase = "10e22c08-3ccb-4172-bfcf-7d7aa3d04d93"
-QuadGK = "1fd47b50-473d-5c70-9696-f719f8f3bcdc"
-Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
-SafeTestsets = "1bc83da4-3b8d-516f-aca4-4fe02f6d838f"
-Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"

--- a/test/interfaces/background_field_interface.jl
+++ b/test/interfaces/background_field_interface.jl
@@ -1,4 +1,4 @@
-import QEDbase
+using QEDbase: QEDbase
 using QEDcore
 using QEDfields
 using Random

--- a/test/interfaces/background_field_interface.jl
+++ b/test/interfaces/background_field_interface.jl
@@ -1,4 +1,5 @@
-using QEDbase
+import QEDbase
+using QEDcore
 using QEDfields
 using Random
 using IntervalSets
@@ -14,10 +15,10 @@ RND_DOMAIN = Interval(-rand(RNG), rand(RNG))
 RND_DOMAIN_WIDTH = width(RND_DOMAIN)
 _groundtruth_envelope(x::Real) = one(x)
 _groundtruth_envelope(x::AbstractVector) = ones(size(x))
-_groundtruth_amplitude(::QEDfields.PolX, x) = cos(x)
-_groundtruth_amplitude(::QEDfields.PolY, x) = sin(x)
+_groundtruth_amplitude(::QEDbase.PolX, x) = cos(x)
+_groundtruth_amplitude(::QEDbase.PolY, x) = sin(x)
 
-function _indefinite_integral(::QEDfields.PolX, x, l)
+function _indefinite_integral(::QEDbase.PolX, x, l)
     # according to wolframalpha.com
     if l == zero(l)
         return sin(x)
@@ -30,7 +31,7 @@ function _indefinite_integral(::QEDfields.PolX, x, l)
     end
 end
 
-function _indefinite_integral(::QEDfields.PolY, x, l)
+function _indefinite_integral(::QEDbase.PolY, x, l)
     # according to wolframalpha.com
     if l == zero(l)
         return -cos(x)
@@ -133,7 +134,7 @@ end
 end
 
 @testset "pulse amplitude" begin
-    @testset "$pol" for pol in (QEDfields.PolX(), QEDfields.PolY())
+    @testset "$pol" for pol in (QEDbase.PolX(), QEDbase.PolY())
         test_field = TestBGfield()
 
         @testset "compute single" begin
@@ -196,7 +197,7 @@ end
 end
 
 @testset "generic spectrum" begin
-    @testset "$pol" for pol in (QEDfields.PolX(), QEDfields.PolY())
+    @testset "$pol" for pol in (QEDbase.PolX(), QEDbase.PolY())
         test_field = TestBGfield()
 
         @testset "compute single" begin

--- a/test/polarization.jl
+++ b/test/polarization.jl
@@ -1,5 +1,6 @@
 
-using QEDbase
+import QEDbase
+using QEDcore
 using QEDfields
 using Random
 using IntervalSets
@@ -9,7 +10,7 @@ ATOL = eps()
 RTOL = sqrt(eps())
 
 RND_MOM = SFourMomentum(rand(RNG, 4))
-POL_SET = [PolX(), PolY()]
+POL_SET = [QEDbase.PolX(), QEDbase.PolY()]
 
 @testset "polarization vectors" begin
     @testset "$mom" for mom in [SFourMomentum(1, 0, 0, 1), RND_MOM]
@@ -34,9 +35,9 @@ POL_SET = [PolX(), PolY()]
         end
 
         @testset "All pols" begin
-            test_all_pol_vec = polarization_vector(AllPol(), mom)
-            groundtruth_polx_vec = polarization_vector(PolX(), mom)
-            groundtruth_poly_vec = polarization_vector(PolY(), mom)
+            test_all_pol_vec = polarization_vector(QEDbase.AllPol(), mom)
+            groundtruth_polx_vec = polarization_vector(QEDbase.PolX(), mom)
+            groundtruth_poly_vec = polarization_vector(QEDbase.PolY(), mom)
 
             @test isapprox(test_all_pol_vec[1], groundtruth_polx_vec, atol=ATOL, rtol=RTOL)
             @test isapprox(test_all_pol_vec[2], groundtruth_poly_vec, atol=ATOL, rtol=RTOL)
@@ -49,14 +50,14 @@ end
         rnd_arg = rand(RNG, 0:(2pi))
 
         groundtruth_polX = cos(rnd_arg)
-        test_val_polX = oscillator(PolX(), rnd_arg)
+        test_val_polX = oscillator(QEDbase.PolX(), rnd_arg)
         @test isapprox(test_val_polX, groundtruth_polX, atol=ATOL, rtol=RTOL)
 
         groundtruth_polY = sin(rnd_arg)
-        test_val_polY = oscillator(PolY(), rnd_arg)
+        test_val_polY = oscillator(QEDbase.PolY(), rnd_arg)
         @test isapprox(test_val_polY, groundtruth_polY, atol=ATOL, rtol=RTOL)
 
-        test_val_AllPol = oscillator(AllPol(), rnd_arg)
+        test_val_AllPol = oscillator(QEDbase.AllPol(), rnd_arg)
         @test isapprox(test_val_AllPol[1], groundtruth_polX, atol=ATOL, rtol=RTOL)
         @test isapprox(test_val_AllPol[2], groundtruth_polY, atol=ATOL, rtol=RTOL)
     end

--- a/test/polarization.jl
+++ b/test/polarization.jl
@@ -1,5 +1,5 @@
 
-import QEDbase
+using QEDbase: QEDbase
 using QEDcore
 using QEDfields
 using Random

--- a/test/pulses/cos_square.jl
+++ b/test/pulses/cos_square.jl
@@ -1,7 +1,8 @@
 using Random
 using IntervalSets
 using QEDfields
-using QEDbase
+import QEDbase
+using QEDcore
 using QuadGK
 
 RNG = MersenneTwister(123456789)
@@ -48,11 +49,11 @@ end
         wrapper_pulse = CosSquarePulseWrapper(test_pulse)
         test_pnums = [1.0, -1.0, 1 + rand(RNG) * 0.1, -1 - rand(RNG) * 0.1]
         @testset "pnum: $pnum" for pnum in test_pnums
-            test_val_xpol = generic_spectrum(test_pulse, PolX(), pnum)
-            test_val_ypol = generic_spectrum(test_pulse, PolY(), pnum)
+            test_val_xpol = generic_spectrum(test_pulse, QEDbase.PolX(), pnum)
+            test_val_ypol = generic_spectrum(test_pulse, QEDbase.PolY(), pnum)
 
-            groundtruth_xpol = generic_spectrum(wrapper_pulse, PolX(), pnum)
-            groundtruth_ypol = generic_spectrum(wrapper_pulse, PolY(), pnum)
+            groundtruth_xpol = generic_spectrum(wrapper_pulse, QEDbase.PolX(), pnum)
+            groundtruth_ypol = generic_spectrum(wrapper_pulse, QEDbase.PolY(), pnum)
 
             @test isapprox(test_val_xpol, groundtruth_xpol, atol=ATOL, rtol=RTOL)
             @test isapprox(test_val_ypol, groundtruth_ypol, atol=ATOL, rtol=RTOL)

--- a/test/pulses/cos_square.jl
+++ b/test/pulses/cos_square.jl
@@ -1,7 +1,7 @@
 using Random
 using IntervalSets
 using QEDfields
-import QEDbase
+using QEDbase: QEDbase
 using QEDcore
 using QuadGK
 


### PR DESCRIPTION
This opts out the `QEDbase` namespace and adds the dependency on `QEDcore`. 

This is part of the general restructuring of `QED.jl`, see https://github.com/QEDjl-project/QED.jl/issues/35 for details. 