### PR TITLE
Use base_state from core

### DIFF
--- a/src/polarization.jl
+++ b/src/polarization.jl
@@ -22,7 +22,7 @@ where as for an indefinite polarization, a tuple of polarization vectors is retu
 
 """
 @inline function polarization_vector(pol::QEDbase.AbstractPolarization, mom)
-    return QEDbase.base_state(QEDbase.Photon(), QEDbase.Incoming(), mom, pol)
+    return base_state(Photon(), QEDbase.Incoming(), mom, pol)
 end
 
 """

--- a/test/downstream.jl
+++ b/test/downstream.jl
@@ -2,7 +2,6 @@
 # check if upstream packages provide the assumed functionality
 ###################
 
-
 # TODO: remove this because it is covered by the integration tests
 
 using Pkg: Pkg

--- a/test/downstream.jl
+++ b/test/downstream.jl
@@ -2,6 +2,9 @@
 # check if upstream packages provide the assumed functionality
 ###################
 
+
+# TODO: remove this because it is covered by the integration tests
+
 using Pkg: Pkg
 
 # QEDbase.jl

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -2,7 +2,6 @@ using QEDfields
 using Test
 using SafeTestsets
 
-
 # -> this is covered by integration tests
 # @time @safetestset "downstream" begin
 #     include("downstream.jl")

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -2,9 +2,11 @@ using QEDfields
 using Test
 using SafeTestsets
 
-@time @safetestset "downstream" begin
-    include("downstream.jl")
-end
+
+# -> this is covered by integration tests
+# @time @safetestset "downstream" begin
+#     include("downstream.jl")
+# end
 
 @time @safetestset "background field interface" begin
     include("interfaces/background_field_interface.jl")


### PR DESCRIPTION
With this PR, QEDfields should use `base_state` from QEDcore, not from QEDbase. 

This is part of the general restructuring of `QED.jl`, see https://github.com/QEDjl-project/QED.jl/issues/35 for details. 