### PR TITLE
Refac cleanup

### DIFF
--- a/.github/workflows/BuildDelopyDoc.yml
+++ b/.github/workflows/BuildDelopyDoc.yml
@@ -25,7 +25,6 @@ jobs:
           julia --project=docs/ -e 'import Pkg; Pkg.Registry.add(Pkg.RegistrySpec(url="https://github.com/JuliaRegistries/General"));'
       - name: Install dependencies
         run: |
-          julia --project=docs/ add_QEDcore_dev.jl
           julia --project=docs/ -e 'using Pkg; Pkg.develop(PackageSpec(path=pwd())); Pkg.instantiate()'
       - name: Build and deploy
         env:

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -11,7 +11,6 @@ stages:
     - git clone --depth 1 -b dev https://github.com/QEDjl-project/QED.jl.git /QEDjl
     - julia --project=. -e 'import Pkg; Pkg.Registry.add(Pkg.RegistrySpec(url="https://github.com/QEDjl-project/registry.git"));'
     - julia --project=. -e 'import Pkg; Pkg.Registry.add(Pkg.RegistrySpec(url="https://github.com/JuliaRegistries/General"));'
-    - julia --project=. add_QEDcore_dev.jl
     - >
       if [[ $CI_COMMIT_BRANCH == "main" || $CI_COMMIT_REF_NAME == "main" || $CI_COMMIT_BRANCH == "dev" || $CI_COMMIT_REF_NAME == "dev" ]]; then
         # set name of the commit message from CI_COMMIT_MESSAGE to NO_MESSAGE, that the script does not read accidentally custom packages from the commit message of a merge commit

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 :warning: This package is under construction and only contains dummy functionality for testing.
 
-: warning: currently this is based on a dev-version of QEDcore. Please make sure that you use the QEDjl registry below.
+:warning: currently this is based on a dev-version of QEDcore. Please make sure that you use the QEDjl registry below.
 
 ## Installation
 

--- a/README.md
+++ b/README.md
@@ -5,10 +5,8 @@
 [![Code Style: Blue](https://img.shields.io/badge/code%20style-blue-4495d1.svg)](https://github.com/invenia/BlueStyle)
 
 :warning: This package is under construction and only contains dummy functionality for testing.
-:> [!WARNING]
 
-> currently this is based on a dev-version of QEDcore. Please make sure that you use the
-> QEDjl registry below.
+: warning: currently this is based on a dev-version of QEDcore. Please make sure that you use the QEDjl registry below.
 
 ## Installation
 

--- a/README.md
+++ b/README.md
@@ -4,8 +4,11 @@
 [![Doc Dev](https://img.shields.io/badge/docs-dev-blue.svg)](https://qedjl-project.github.io/QEDfields.jl/dev)
 [![Code Style: Blue](https://img.shields.io/badge/code%20style-blue-4495d1.svg)](https://github.com/invenia/BlueStyle)
 
-
 :warning: This package is under construction and only contains dummy functionality for testing.
+:> [!WARNING]
+
+> currently this is based on a dev-version of QEDcore. Please make sure that you use the
+> QEDjl registry below.
 
 ## Installation
 

--- a/src/QEDfields.jl
+++ b/src/QEDfields.jl
@@ -1,19 +1,10 @@
 module QEDfields
 
-using QEDbase: QEDbase
+using QEDbase
 using QEDcore
 
 using IntervalSets
 using QuadGK
-
-export dummy_QEDbase
-
-# Write your package code here.
-function dummy_QEDbase(x::AbstractVector{T}) where {T<:Real}
-    length(x) == 4 ||
-        error("The length of the input needs to be four. <$(length(x))> given.")
-    @inbounds SFourMomentum(x...)
-end
 
 export AbstractBackgroundField, AbstractPulsedPlaneWaveField
 export reference_momentum, domain, pulse_length, envelope, amplitude, generic_spectrum

--- a/src/interfaces/background_field_interface.jl
+++ b/src/interfaces/background_field_interface.jl
@@ -113,9 +113,7 @@ end
 # amplitude functions
 
 function _amplitude(
-    field::AbstractPulsedPlaneWaveField,
-    pol::AbstractDefinitePolarization,
-    phi::Real,
+    field::AbstractPulsedPlaneWaveField, pol::AbstractDefinitePolarization, phi::Real
 )
     return oscillator(pol, phi) * _envelope(field, phi)
 end
@@ -150,9 +148,7 @@ Returns the value of the amplitude for a given polarization direction and phase 
     the value of the amplitude is returned, and zero otherwise.
 """
 function amplitude(
-    field::AbstractPulsedPlaneWaveField,
-    pol::AbstractDefinitePolarization,
-    phi::Real,
+    field::AbstractPulsedPlaneWaveField, pol::AbstractDefinitePolarization, phi::Real
 )
     return phi in domain(field) ? _amplitude(field, pol, phi) : zero(phi)
 end
@@ -191,9 +187,7 @@ Return the generic spectrum of the given field, for the given polarization direc
     where ``g(\\phi)`` is the [`envelope`](@ref) and ``l`` the photon number parameter.
 """
 function generic_spectrum(
-    field::AbstractPulsedPlaneWaveField,
-    pol::AbstractDefinitePolarization,
-    pnum::Real,
+    field::AbstractPulsedPlaneWaveField, pol::AbstractDefinitePolarization, pnum::Real
 )
     return _fourier_transform(t -> _amplitude(field, pol, t), domain(field), pnum)
 end

--- a/src/interfaces/background_field_interface.jl
+++ b/src/interfaces/background_field_interface.jl
@@ -114,7 +114,7 @@ end
 
 function _amplitude(
     field::AbstractPulsedPlaneWaveField,
-    pol::QEDbase.AbstractDefinitePolarization,
+    pol::AbstractDefinitePolarization,
     phi::Real,
 )
     return oscillator(pol, phi) * _envelope(field, phi)
@@ -122,7 +122,7 @@ end
 
 function _amplitude(
     field::AbstractPulsedPlaneWaveField,
-    pol::QEDbase.AbstractDefinitePolarization,
+    pol::AbstractDefinitePolarization,
     phi::AbstractVector{T},
 ) where {T<:Real}
     # TODO: maybe use broadcasting here 
@@ -151,7 +151,7 @@ Returns the value of the amplitude for a given polarization direction and phase 
 """
 function amplitude(
     field::AbstractPulsedPlaneWaveField,
-    pol::QEDbase.AbstractDefinitePolarization,
+    pol::AbstractDefinitePolarization,
     phi::Real,
 )
     return phi in domain(field) ? _amplitude(field, pol, phi) : zero(phi)
@@ -159,7 +159,7 @@ end
 
 function amplitude(
     field::AbstractPulsedPlaneWaveField,
-    pol::QEDbase.AbstractDefinitePolarization,
+    pol::AbstractDefinitePolarization,
     phi::AbstractVector{T},
 ) where {T<:Real}
     # TODO: maybe use broadcasting here 
@@ -192,7 +192,7 @@ Return the generic spectrum of the given field, for the given polarization direc
 """
 function generic_spectrum(
     field::AbstractPulsedPlaneWaveField,
-    pol::QEDbase.AbstractDefinitePolarization,
+    pol::AbstractDefinitePolarization,
     pnum::Real,
 )
     return _fourier_transform(t -> _amplitude(field, pol, t), domain(field), pnum)
@@ -200,7 +200,7 @@ end
 
 function generic_spectrum(
     field::AbstractPulsedPlaneWaveField,
-    pol::QEDbase.AbstractDefinitePolarization,
+    pol::AbstractDefinitePolarization,
     photon_number_parameter::AbstractVector{T},
 ) where {T<:Real}
     # TODO: maybe use broadcasting here 

--- a/src/polarization.jl
+++ b/src/polarization.jl
@@ -21,8 +21,8 @@ where as for an indefinite polarization, a tuple of polarization vectors is retu
     In the current implementation, we use the `base_state` function for `Photon` provided by `QEDcore.jl`.
 
 """
-@inline function polarization_vector(pol::QEDbase.AbstractPolarization, mom)
-    return base_state(Photon(), QEDbase.Incoming(), mom, pol)
+@inline function polarization_vector(pol::AbstractPolarization, mom)
+    return base_state(Photon(), Incoming(), mom, pol)
 end
 
 """
@@ -44,9 +44,9 @@ Return the value of the base oscillator associated with a given polarization `po
 """
 function oscillator end
 
-@inline oscillator(::QEDbase.PolX, phi) = cos(phi)
-@inline oscillator(::QEDbase.PolY, phi) = sin(phi)
-@inline function oscillator(::QEDbase.AbstractIndefinitePolarization, phi)
+@inline oscillator(::PolX, phi) = cos(phi)
+@inline oscillator(::PolY, phi) = sin(phi)
+@inline function oscillator(::AbstractIndefinitePolarization, phi)
     sincos_res = sincos(phi)
     @inbounds cossin_res = (sincos_res[2], sincos_res[1])
     return cossin_res

--- a/src/pulses/cos_square.jl
+++ b/src/pulses/cos_square.jl
@@ -18,7 +18,7 @@ Concrete implementation of an `AbstractPulsedPlaneWaveField` for cos-square puls
     for \$\\phi\\in (-\\Delta\\phi,\\Delta\\phi)\$, where \$\\Delta\\phi\$ denotes the `pulse_length`, and zero otherwise.
 
 """
-struct CosSquarePulse{M<:QEDbase.AbstractFourMomentum,T<:Real} <:
+struct CosSquarePulse{M<:AbstractFourMomentum,T<:Real} <:
        AbstractPulsedPlaneWaveField
     mom::M
     pulse_length::T
@@ -57,12 +57,12 @@ end
     return sig * _gsinc(sig * l / pi)
 end
 
-function generic_spectrum(field::CosSquarePulse, pol::QEDbase.PolX, pnum::Real)
+function generic_spectrum(field::CosSquarePulse, pol::PolX, pnum::Real)
     dphi = field.pulse_length
     return 0.5 * (_generic_FT(pnum + 1, dphi) + _generic_FT(pnum - 1, dphi))
 end
 
-function generic_spectrum(field::CosSquarePulse, pol::QEDbase.PolY, pnum::Real)
+function generic_spectrum(field::CosSquarePulse, pol::PolY, pnum::Real)
     dphi = field.pulse_length
     return -0.5im * (_generic_FT(pnum + 1, dphi) - _generic_FT(pnum - 1, dphi))
 end

--- a/src/pulses/cos_square.jl
+++ b/src/pulses/cos_square.jl
@@ -18,8 +18,7 @@ Concrete implementation of an `AbstractPulsedPlaneWaveField` for cos-square puls
     for \$\\phi\\in (-\\Delta\\phi,\\Delta\\phi)\$, where \$\\Delta\\phi\$ denotes the `pulse_length`, and zero otherwise.
 
 """
-struct CosSquarePulse{M<:AbstractFourMomentum,T<:Real} <:
-       AbstractPulsedPlaneWaveField
+struct CosSquarePulse{M<:AbstractFourMomentum,T<:Real} <: AbstractPulsedPlaneWaveField
     mom::M
     pulse_length::T
 end


### PR DESCRIPTION
The namespace shadowing of QEDbase is revoked. This is part of the restructuring of `QED.jl`. See https://github.com/QEDjl-project/QED.jl/issues/35 for details.