### PR TITLE
CI: set QED dependencies for doc build to dev branch version, if target branch is not main

### DIFF
--- a/.github/workflows/BuildDeployDoc.yml
+++ b/.github/workflows/BuildDeployDoc.yml
@@ -26,6 +26,11 @@ jobs:
       - name: Install dependencies
         run: |
           julia --project=docs/ -e 'using Pkg; Pkg.develop(PackageSpec(path=pwd())); Pkg.instantiate()'
+      - name: set dependencies to dev branch version
+        if: (github.event_name == 'push' && github.ref_name != 'main') || (github.event_name == 'pull_request' && github.base_ref != 'main')
+        run: |
+          git clone -b dev https://github.com/QEDjl-project/QED.jl.git /tmp/integration_test_tools
+          julia --project=docs/ /tmp/integration_test_tools/.ci/set_dev_dependencies.jl
       - name: Build and deploy
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} # If authenticating with GitHub Actions token


### PR DESCRIPTION
Copy of: https://github.com/QEDjl-project/QEDprocesses.jl/pull/95