### PR TITLE
Add fccquad

### DIFF
--- a/.github/workflows/BuildDeployDoc.yml
+++ b/.github/workflows/BuildDeployDoc.yml
@@ -5,7 +5,7 @@ on:
     branches:
       - main
       - dev
-    tags: '*'
+    tags: "*"
   pull_request:
 
 jobs:
@@ -17,4 +17,5 @@ jobs:
     steps:
       - uses: QEDjl-project/gh-actions/build-docs@v1
         with:
+          julia-version: "1.12"
           github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/Project.toml
+++ b/Project.toml
@@ -1,15 +1,10 @@
 name = "QEDfields"
 uuid = "ac3a6c97-e859-4b9f-96bb-63d2a216042c"
-authors = [
-    "Uwe Hernandez Acosta <u.hernandez@hzdr.de>",
-    "Simeon Ehrig",
-    "Klaus Steiniger",
-    "Tom Jungnickel",
-    "Anton Reinhard",
-]
 version = "0.3.1"
+authors = ["Uwe Hernandez Acosta <u.hernandez@hzdr.de>", "Simeon Ehrig", "Klaus Steiniger", "Tom Jungnickel", "Anton Reinhard"]
 
 [deps]
+FCCQuad = "7e58c0cd-f370-453c-9274-eb333b7aace6"
 FastGaussQuadrature = "442a2c76-b920-505d-bb47-c5924d526838"
 GaussQuadrature = "d54b0c1a-921d-58e0-8e36-89d8069c0969"
 IntervalSets = "8197267c-284f-5f27-9208-e0e47529a953"
@@ -19,7 +14,14 @@ QEDcore = "35dc0263-cb5f-4c33-a114-1d7f54ab753e"
 QuadGK = "1fd47b50-473d-5c70-9696-f719f8f3bcdc"
 SpecialFunctions = "276daf66-3868-5448-9aa4-cd146d93841b"
 
+[sources]
+FCCQuad = {rev = "master", url = "https://github.com/dkm2/FCCQuad.jl"}
+
+[extensions]
+FCCQuadExt = "FCCQuad"
+
 [compat]
+FCCQuad = "0.4.16"
 FastGaussQuadrature = "1.0.2"
 GaussQuadrature = "0.5.8"
 IntervalSets = "0.7"

--- a/Project.toml
+++ b/Project.toml
@@ -6,7 +6,6 @@ authors = ["Uwe Hernandez Acosta <u.hernandez@hzdr.de>", "Simeon Ehrig", "Klaus 
 [deps]
 FCCQuad = "7e58c0cd-f370-453c-9274-eb333b7aace6"
 FastGaussQuadrature = "442a2c76-b920-505d-bb47-c5924d526838"
-GaussQuadrature = "d54b0c1a-921d-58e0-8e36-89d8069c0969"
 IntervalSets = "8197267c-284f-5f27-9208-e0e47529a953"
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 QEDbase = "10e22c08-3ccb-4172-bfcf-7d7aa3d04d93"
@@ -23,7 +22,6 @@ FCCQuadExt = "FCCQuad"
 [compat]
 FCCQuad = "0.4.16"
 FastGaussQuadrature = "1.0.2"
-GaussQuadrature = "0.5.8"
 IntervalSets = "0.7"
 LinearAlgebra = "1.10.0"
 QEDbase = "0.5"

--- a/Project.toml
+++ b/Project.toml
@@ -1,10 +1,15 @@
 name = "QEDfields"
 uuid = "ac3a6c97-e859-4b9f-96bb-63d2a216042c"
 version = "0.3.1"
-authors = ["Uwe Hernandez Acosta <u.hernandez@hzdr.de>", "Simeon Ehrig", "Klaus Steiniger", "Tom Jungnickel", "Anton Reinhard"]
+authors = [
+    "Uwe Hernandez Acosta <u.hernandez@hzdr.de>",
+    "Simeon Ehrig",
+    "Klaus Steiniger",
+    "Tom Jungnickel",
+    "Anton Reinhard",
+]
 
 [deps]
-FCCQuad = "7e58c0cd-f370-453c-9274-eb333b7aace6"
 FastGaussQuadrature = "442a2c76-b920-505d-bb47-c5924d526838"
 IntervalSets = "8197267c-284f-5f27-9208-e0e47529a953"
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
@@ -13,14 +18,13 @@ QEDcore = "35dc0263-cb5f-4c33-a114-1d7f54ab753e"
 QuadGK = "1fd47b50-473d-5c70-9696-f719f8f3bcdc"
 SpecialFunctions = "276daf66-3868-5448-9aa4-cd146d93841b"
 
-[sources]
-FCCQuad = {rev = "master", url = "https://github.com/dkm2/FCCQuad.jl"}
+[weakdeps]
+FCCQuadrature = "7e58c0cd-f370-453c-9274-eb333b7aace6"
 
 [extensions]
-FCCQuadExt = "FCCQuad"
+FCCQuadratureExt = "FCCQuadrature"
 
 [compat]
-FCCQuad = "0.4.16"
 FastGaussQuadrature = "1.0.2"
 IntervalSets = "0.7"
 LinearAlgebra = "1.10.0"
@@ -35,6 +39,7 @@ Pkg = "44cfe95a-1eb2-52ea-b672-e2afdf69b78f"
 Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
 SafeTestsets = "1bc83da4-3b8d-516f-aca4-4fe02f6d838f"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
+FCCQuadrature = "7e58c0cd-f370-453c-9274-eb333b7aace6"
 
 [targets]
-test = ["Pkg", "Random", "SafeTestsets", "Test"]
+test = ["Pkg", "Random", "SafeTestsets", "Test", "FCCQuadrature"]

--- a/docs/Project.toml
+++ b/docs/Project.toml
@@ -4,5 +4,5 @@ FCCQuad = "7e58c0cd-f370-453c-9274-eb333b7aace6"
 QEDfields = "ac3a6c97-e859-4b9f-96bb-63d2a216042c"
 
 [sources]
-FCCQuad = {rev = "master", url = "https://github.com/dkm2/FCCQuad.jl"}
-QEDfields = {path = "/Users/uwe/Work/jlProjects/QEDjl-project/forks/QEDfields.jl"}
+FCCQuad = { rev = "master", url = "https://github.com/dkm2/FCCQuad.jl" }
+QEDfields = { path = "/Users/uwe/Work/jlProjects/QEDjl-project/forks/QEDfields.jl" }

--- a/docs/Project.toml
+++ b/docs/Project.toml
@@ -2,6 +2,3 @@
 Documenter = "e30172f5-a6a5-5a46-863b-614d45cd2de4"
 FCCQuadrature = "7e58c0cd-f370-453c-9274-eb333b7aace6"
 QEDfields = "ac3a6c97-e859-4b9f-96bb-63d2a216042c"
-
-[sources]
-QEDfields = {path = "/Users/uwe/Work/jlProjects/QEDjl-project/forks/QEDfields.jl"}

--- a/docs/Project.toml
+++ b/docs/Project.toml
@@ -1,7 +1,7 @@
 [deps]
 Documenter = "e30172f5-a6a5-5a46-863b-614d45cd2de4"
-FCCQuad = "7e58c0cd-f370-453c-9274-eb333b7aace6"
+FCCQuadrature = "7e58c0cd-f370-453c-9274-eb333b7aace6"
 QEDfields = "ac3a6c97-e859-4b9f-96bb-63d2a216042c"
 
 [sources]
-FCCQuad = { rev = "master", url = "https://github.com/dkm2/FCCQuad.jl" }
+QEDfields = {path = "/Users/uwe/Work/jlProjects/QEDjl-project/forks/QEDfields.jl"}

--- a/docs/Project.toml
+++ b/docs/Project.toml
@@ -5,4 +5,3 @@ QEDfields = "ac3a6c97-e859-4b9f-96bb-63d2a216042c"
 
 [sources]
 FCCQuad = { rev = "master", url = "https://github.com/dkm2/FCCQuad.jl" }
-QEDfields = { path = "/Users/uwe/Work/jlProjects/QEDjl-project/forks/QEDfields.jl" }

--- a/docs/Project.toml
+++ b/docs/Project.toml
@@ -1,3 +1,8 @@
 [deps]
 Documenter = "e30172f5-a6a5-5a46-863b-614d45cd2de4"
+FCCQuad = "7e58c0cd-f370-453c-9274-eb333b7aace6"
 QEDfields = "ac3a6c97-e859-4b9f-96bb-63d2a216042c"
+
+[sources]
+FCCQuad = {rev = "master", url = "https://github.com/dkm2/FCCQuad.jl"}
+QEDfields = {path = "/Users/uwe/Work/jlProjects/QEDjl-project/forks/QEDfields.jl"}

--- a/ext/FCCQuadExt.jl
+++ b/ext/FCCQuadExt.jl
@@ -51,13 +51,12 @@ function QEDfields.phase_integrals(
     max_amp = maximum_amplitude(field)
 
     # TODO: make max_amp factors global
+    osc = x -> exp(1im * QEDfields._volkov_phase(field, internal_integral_method, x, beta1, beta2))
     pre1 = x -> max_amp * QEDfields._amplitude(field, x)
-    osc1 = x -> exp(1im * QEDfields._volkov_phase(field, internal_integral_method, x, beta1, beta2))
     pre2 = x -> max_amp^2 * QEDfields._amplitude(field, x)^2
-    osc2 = x -> exp(1im * QEDfields._volkov_phase(field, internal_integral_method, x, beta1, beta2))
 
-    res1, nevals1 = _fccquad(pre1, osc1, _as_vec(pnum); xmin = a, xmax = b, integrator = phase_integral_method)
-    res2, nevals2 = _fccquad(pre2, osc2, _as_vec(pnum); xmin = a, xmax = b, integrator = phase_integral_method)
+    res1, nevals1 = _fccquad(pre1, osc, _as_vec(pnum); xmin = a, xmax = b, integrator = phase_integral_method)
+    res2, nevals2 = _fccquad(pre2, osc, _as_vec(pnum); xmin = a, xmax = b, integrator = phase_integral_method)
     return PhaseIntegrals(
         PhaseIntegralResult(QEDfields._tuple_pack(res1[:, 1])...),
         PhaseIntegralResult(QEDfields._tuple_pack(res2[:, 1])...),

--- a/ext/FCCQuadExt.jl
+++ b/ext/FCCQuadExt.jl
@@ -1,0 +1,67 @@
+module FCCQuadExt
+
+using FCCQuad
+using QEDfields
+using IntervalSets
+
+
+@inline function _fccquad(
+        prefactor::Function,
+        oscillator::Function,
+        freqs::AbstractVector{<:Real};
+        xmin,
+        xmax,
+        integrator::FilonClenshawCurtisQuadrature{T}
+    ) where {T}
+
+    return fccquad(
+        prefactor, oscillator, freqs;
+        T = T,
+        xmin = xmin,
+        xmax = xmax,
+        reltol = integrator.reltol,
+        abstol = integrator.abstol,
+        method = integrator.method,
+        vectornorm = integrator.vectornorm,
+        branching = integrator.branching,
+        maxdepth = integrator.maxdepth,
+        minlog2degree = integrator.minlog2degree,
+        localmaxlog2degree = integrator.localmaxlog2degree,
+        nonadaptivelog2degree = integrator.nonadaptivelog2degree,
+        globalmaxlog2degree = integrator.globalmaxlog2degree,
+    )
+end
+
+_as_vec(x::AbstractVector) = x
+_as_vec(x::Number) = [x]
+function QEDfields.phase_integrals(
+        field::QEDfields.AbstractPlaneWaveField{P},
+        internal_integral_method::QEDfields.AbstractIntegrationMethod,
+        phase_integral_method::FilonClenshawCurtisQuadrature,
+        pnum::T,
+        beta1::T,
+        beta2::T
+    )::PhaseIntegrals{Complex{T}, 2} where {
+        T <: Real,
+        P <: QEDfields.AbstractDefinitePolarization,
+    }
+
+    dom = compact_domain(field)
+    a, b = endpoints(dom)
+    max_amp = maximum_amplitude(field)
+
+    # TODO: make max_amp factors global
+    pre1 = x -> max_amp * QEDfields._amplitude(field, x)
+    osc1 = x -> exp(1im * QEDfields._volkov_phase(field, internal_integral_method, x, beta1, beta2))
+    pre2 = x -> max_amp^2 * QEDfields._amplitude(field, x)^2
+    osc2 = x -> exp(1im * QEDfields._volkov_phase(field, internal_integral_method, x, beta1, beta2))
+
+    res1, nevals1 = _fccquad(pre1, osc1, _as_vec(pnum); xmin = a, xmax = b, integrator = phase_integral_method)
+    res2, nevals2 = _fccquad(pre2, osc2, _as_vec(pnum); xmin = a, xmax = b, integrator = phase_integral_method)
+    return PhaseIntegrals(
+        PhaseIntegralResult(QEDfields._tuple_pack(res1[:, 1])...),
+        PhaseIntegralResult(QEDfields._tuple_pack(res2[:, 1])...),
+    )
+end
+
+end

--- a/ext/FCCQuadratureExt.jl
+++ b/ext/FCCQuadratureExt.jl
@@ -1,6 +1,6 @@
-module FCCQuadExt
+module FCCQuadratureExt
 
-using FCCQuad
+using FCCQuadrature
 using QEDfields
 using IntervalSets
 

--- a/ext/FCCQuadratureExt.jl
+++ b/ext/FCCQuadratureExt.jl
@@ -1,9 +1,9 @@
 module FCCQuadratureExt
 
 using FCCQuadrature
+using FCCQuadrature.Duals: Dual
 using QEDfields
 using IntervalSets
-
 
 @inline function _fccquad(
         prefactor::Function,
@@ -62,5 +62,7 @@ function QEDfields.phase_integrals(
         PhaseIntegralResult(QEDfields._tuple_pack(res2[:, 1])...),
     )
 end
+
+QEDfields._sinc(d::Dual) = iszero(d.a) ? Dual(one(d.a), zero(d.a)) : sin(d) / d
 
 end

--- a/src/QEDfields.jl
+++ b/src/QEDfields.jl
@@ -35,6 +35,7 @@ export GaussianPulse
 export integrate
 export GaussKronrodQuadrature
 export GaussLegendreQuadrature
+export FilonClenshawCurtisQuadrature, FCCQuadrature
 export Analytical
 
 using QuadGK
@@ -54,6 +55,7 @@ include("results.jl")
 include("integration_methods/interface.jl")
 include("integration_methods/gauss_kronrod.jl")
 include("integration_methods/gauss_legendre.jl")
+include("integration_methods/filon_clenshaw_curtis.jl")
 include("integration_methods/analytical.jl")
 
 include("interface.jl")

--- a/src/QEDfields.jl
+++ b/src/QEDfields.jl
@@ -35,7 +35,7 @@ export GaussianPulse
 export integrate
 export GaussKronrodQuadrature
 export GaussLegendreQuadrature
-export FilonClenshawCurtisQuadrature, FCCQuadrature
+export FilonClenshawCurtisQuadrature
 export Analytical
 
 using QuadGK

--- a/src/QEDfields.jl
+++ b/src/QEDfields.jl
@@ -40,7 +40,6 @@ export Analytical
 
 using QuadGK
 using FastGaussQuadrature
-using GaussQuadrature
 using IntervalSets
 using LinearAlgebra
 using SpecialFunctions

--- a/src/generic/internal_integrals.jl
+++ b/src/generic/internal_integrals.jl
@@ -1,6 +1,6 @@
 ### internal integrals
 
-@inline function _internal_integrals(field::AbstractPlaneWaveField{P}, method::AbstractIntegrationMethod, phi::T) where {T <: Real, P <: AbstractDefinitePolarization}
+@inline function _internal_integrals(field::AbstractPlaneWaveField{P}, method::AbstractIntegrationMethod, phi::T) where {T <: Number, P <: AbstractDefinitePolarization}
     tmp_func1 = t -> _amplitude(field, t)
     tmp_func2 = t -> _amplitude(field, t)^2
 
@@ -10,7 +10,7 @@
 end
 
 # FIXME: This is wrong! We need to insert the xi-dependent terms
-@inline function _internal_integrals(field::AbstractPlaneWaveField{P}, method::AbstractIntegrationMethod, phi::T) where {T <: Real, P <: AbstractIndefinitePolarization}
+@inline function _internal_integrals(field::AbstractPlaneWaveField{P}, method::AbstractIntegrationMethod, phi::T) where {T <: Number, P <: AbstractIndefinitePolarization}
     tmp_func11 = t -> _amplitude(field, t, PolX())
     tmp_func12 = t -> _amplitude(field, t, PolY())
     tmp_func2 = t -> _amplitude(field, t, PolX())^2 + _amplitude(field, t, PolY())^2
@@ -21,7 +21,7 @@ end
     return InternalIntegrals(res12, res12, res2)
 end
 
-function internal_integrals(field::AbstractPlaneWaveField{P}, method::AbstractIntegrationMethod, phi::T)::InternalIntegrals{T, 2} where {T <: Real, P <: AbstractDefinitePolarization}
+function internal_integrals(field::AbstractPlaneWaveField{P}, method::AbstractIntegrationMethod, phi::T)::InternalIntegrals{T, 2} where {T <: Number, P <: AbstractDefinitePolarization}
 
     dom = compact_domain(field)
 

--- a/src/generic/phase_integrals.jl
+++ b/src/generic/phase_integrals.jl
@@ -1,6 +1,7 @@
 # TBW
 
-_tuple_pack(x::T) where {T <: Number} = (x,)
+_tuple_pack(x::Number) = (x,)
+_tuple_pack(x::AbstractVector) = Tuple(x)
 _tuple_pack(x::Tuple) = x
 
 function phase_integrals(
@@ -19,8 +20,8 @@ function phase_integrals(
     max_amp = maximum_amplitude(field)
 
     # TODO: make max_amp factors global
-    integrand1 = x -> max_amp * _amplitude(field, x) * exp(1im * pnum * x + 1im * volkov_phase(field, internal_integral_method, x, beta1, beta2))
-    integrand2 = x -> max_amp^2 * _amplitude(field, x)^2 * exp(1im * pnum * x + 1im * volkov_phase(field, internal_integral_method, x, beta1, beta2))
+    integrand1 = x -> max_amp * _amplitude(field, x) * exp(1im * pnum * x + 1im * _volkov_phase(field, internal_integral_method, x, beta1, beta2))
+    integrand2 = x -> max_amp^2 * _amplitude(field, x)^2 * exp(1im * pnum * x + 1im * _volkov_phase(field, internal_integral_method, x, beta1, beta2))
 
     res1 = integrate(phase_integral_method, integrand1, dom)
     res2 = integrate(phase_integral_method, integrand2, dom)
@@ -49,9 +50,9 @@ function phase_integrals(
     max_amp = maximum_amplitude(field)
 
     # TODO: make max_amp factors global
-    integrand11 = x -> max_amp * _amplitude(field, PolX(), x) * exp(1im * pnum * x + 1im * volkov_phase(field, x, beta11, beta12, beta2))
-    integrand12 = x -> max_amp * _amplitude(field, PolY(), x) * exp(1im * pnum * x + 1im * volkov_phase(field, x, beta11, beta12, beta2))
-    integrand2 = x -> max_amp^2 * (_amplitude(field, PolX(), x)^2 + _amplitude(field, PolY(), x)^2) * exp(1im * pnum * x + 1im * volkov_phase(field, x, beta11, beta12, beta2))
+    integrand11 = x -> max_amp * _amplitude(field, PolX(), x) * exp(1im * pnum * x + 1im * _volkov_phase(field, x, beta11, beta12, beta2))
+    integrand12 = x -> max_amp * _amplitude(field, PolY(), x) * exp(1im * pnum * x + 1im * _volkov_phase(field, x, beta11, beta12, beta2))
+    integrand2 = x -> max_amp^2 * (_amplitude(field, PolX(), x)^2 + _amplitude(field, PolY(), x)^2) * exp(1im * pnum * x + 1im * _volkov_phase(field, x, beta11, beta12, beta2))
 
     res11 = integrate(method, integrand11, dom)
     res12 = integrate(method, integrand12, dom)

--- a/src/generic/volkov_phase.jl
+++ b/src/generic/volkov_phase.jl
@@ -3,9 +3,9 @@
 function _volkov_phase(
         field::AbstractBackgroundField{<:AbstractDefinitePolarization},
         method::AbstractIntegrationMethod,
-        phi::Real,
-        beta1::Real,
-        beta2::Real
+        phi::Number,
+        beta1::Number,
+        beta2::Number
     )
 
     max_amp = maximum_amplitude(field)
@@ -22,7 +22,7 @@ function volkov_phase(
         phi::T,
         beta1::T,
         beta2::T
-    )::T where {T <: Real}
+    )::T where {T <: Number}
 
     dom = compact_domain(field)
 
@@ -39,10 +39,10 @@ end
 function _volkov_phase(
         field::AbstractBackgroundField{AbstractIndefinitePolarization},
         method::AbstractIntegrationMethod,
-        phi::Real,
-        beta11::Real,
-        beta12::Real,
-        beta2::Real
+        phi::Number,
+        beta11::Number,
+        beta12::Number,
+        beta2::Number
     )
     # add volkov phase for indefinite polarization
 

--- a/src/integration_methods/filon_clenshaw_curtis.jl
+++ b/src/integration_methods/filon_clenshaw_curtis.jl
@@ -64,5 +64,3 @@ struct FilonClenshawCurtisQuadrature{T, V} <: QEDfields.AbstractIntegrationMetho
         )
     end
 end
-
-const FCCQuadrature = FilonClenshawCurtisQuadrature

--- a/src/integration_methods/filon_clenshaw_curtis.jl
+++ b/src/integration_methods/filon_clenshaw_curtis.jl
@@ -1,0 +1,68 @@
+# taken from https://github.com/dkm2/FCCQuad.jl/blob/25d5e17a484ae213871373beccf67a99d111667a/src/FCCQuad.jl#L310C1-L311C1
+const default_reltol = Dict(Float32 => 1.0e-6, Float64 => 1.0e-8, BigFloat => 1.0e-39)
+
+## only the definition, the functionality is placed in the extension
+#=
+Base.@kwdef struct FilonClenshawCurtisQuadrature{T} <: QEDfields.AbstractIntegrationMethod
+
+    T::Type=Complex{Float64}
+    reltol::Real=default_reltol[real(T)]
+    abstol::Real=zero(real(T))
+    method::Symbol=:tone
+
+    vectornorm=LinearAlgebra.norm
+    branching::Integer=4
+    maxdepth::Integer=10
+    maxchirp::Integer=6
+    minlog2degree::Integer=3
+    localmaxlog2degree::Integer=6
+    nonadaptivelog2degree::Integer=10
+    globalmaxlog2degree::Integer=20
+end
+=#
+
+struct FilonClenshawCurtisQuadrature{T, V} <: QEDfields.AbstractIntegrationMethod
+    reltol::Real
+    abstol::Real
+    method::Symbol
+
+    vectornorm::V
+    branching::Integer
+    maxdepth::Integer
+    maxchirp::Integer
+    minlog2degree::Integer
+    localmaxlog2degree::Integer
+    nonadaptivelog2degree::Integer
+    globalmaxlog2degree::Integer
+
+    function FilonClenshawCurtisQuadrature(;
+            T::Type = Complex{Float64},
+            reltol::Real = default_reltol[real(T)],
+            abstol::Real = zero(real(T)),
+            method::Symbol = :tone,
+            vectornorm = LinearAlgebra.norm,
+            branching::Integer = 4,
+            maxdepth::Integer = 10,
+            maxchirp::Integer = 6,
+            minlog2degree::Integer = 3,
+            localmaxlog2degree::Integer = 6,
+            nonadaptivelog2degree::Integer = 10,
+            globalmaxlog2degree::Integer = 20,
+        )
+        return new{T, typeof(vectornorm)}(
+            reltol,
+            abstol,
+            method,
+            vectornorm,
+            branching,
+            maxdepth,
+            maxchirp,
+            minlog2degree,
+            localmaxlog2degree,
+            nonadaptivelog2degree,
+            globalmaxlog2degree,
+        )
+    end
+end
+
+const FCCQuadrature = FilonClenshawCurtisQuadrature

--- a/src/integration_methods/gauss_kronrod.jl
+++ b/src/integration_methods/gauss_kronrod.jl
@@ -10,7 +10,7 @@ Integration method using `QuadGK.quadgk`.
 """
 struct GaussKronrodQuadrature <: AbstractQuadratureMethod end
 
-function integrate(meth::GaussKronrodQuadrature, func::Function, low::Real, high::Real)
+function integrate(meth::GaussKronrodQuadrature, func::Function, low::Number, high::Number)
     res, _ = quadgk(func, low, 0, high)
     return res
 end

--- a/src/integration_methods/gauss_legendre.jl
+++ b/src/integration_methods/gauss_legendre.jl
@@ -37,7 +37,7 @@ function quadrature_weights(method::GaussLegendreQuadrature, low, high)
     return @. fac * method.weights
 end
 
-function integrate(meth::GaussLegendreQuadrature, func::Function, low::Real, high::Real)
+function integrate(meth::GaussLegendreQuadrature, func::Function, low::Number, high::Number)
     n = quadrature_nodes(meth, low, high)
     w = quadrature_weights(meth, low, high)
     return LinearAlgebra.dot(w, func.(n))

--- a/src/pulse_profiles/cos_square/impl.jl
+++ b/src/pulse_profiles/cos_square/impl.jl
@@ -33,6 +33,6 @@ end
 
 pulse_length(pulse::CosSquarePulse) = pulse.pulse_length
 
-function _envelope(pulse::CosSquarePulse, phi::Real)
+function _envelope(pulse::CosSquarePulse, phi::Number)
     return _unsafe_cos_square_envelope(phi, pulse.pulse_length)
 end

--- a/src/pulse_profiles/cos_square/internal_integrals.jl
+++ b/src/pulse_profiles/cos_square/internal_integrals.jl
@@ -1,4 +1,5 @@
-@inline _sinc(x) = sinc(x / pi)
+@inline _sinc(x) = sin(x) / x
+@inline _sinc(x::Real) = sinc(x / pi)
 
 @inline function _internal_integral1_cos_square(::PolX, phi, dphi)
 
@@ -63,7 +64,7 @@ end
 
 # interface
 
-@inline function _internal_integrals(pulse::CosSquarePulse, pol::P, method::Analytical, phi::T) where {T <: Real, P <: AbstractDefinitePolarization}
+@inline function _internal_integrals(pulse::CosSquarePulse, pol::P, method::Analytical, phi::T) where {T <: Number, P <: AbstractDefinitePolarization}
 
     pulse_len = pulse_length(pulse)
     value_I1 = _internal_integral1_cos_square(pol, phi, pulse_len)
@@ -76,7 +77,7 @@ end
 end
 
 # FIXME: This is wrong! We need to insert the xi-dependent terms
-@inline function _internal_integrals(pulse::CosSquarePulse, pol::P, method::Analytical, phi::T) where {T <: Real, P <: AbstractIndefinitePolarization}
+@inline function _internal_integrals(pulse::CosSquarePulse, pol::P, method::Analytical, phi::T) where {T <: Number, P <: AbstractIndefinitePolarization}
     pulse_len = pulse_length(pulse)
     value_I11 = _internal_integral1_cos_square(PolX(), phi, pulse_len)
     value_I12 = _internal_integral2_cos_square(PolY(), phi, pulse_len)

--- a/src/pulse_profiles/cos_square/internal_integrals.jl
+++ b/src/pulse_profiles/cos_square/internal_integrals.jl
@@ -1,5 +1,4 @@
-@inline _sinc(x) = sin(x) / x
-@inline _sinc(x::Real) = sinc(x / pi)
+@inline _sinc(x) = sinc(x / pi)
 
 @inline function _internal_integral1_cos_square(::PolX, phi, dphi)
 

--- a/src/pulse_profiles/gaussian_pulse/impl.jl
+++ b/src/pulse_profiles/gaussian_pulse/impl.jl
@@ -50,6 +50,6 @@ end
 
 pulse_length(pulse::GaussianPulse) = pulse.pulse_length
 
-function _envelope(pulse::GaussianPulse, phi::Real)
+function _envelope(pulse::GaussianPulse, phi::Number)
     return _unsafe_gaussian_envelope(phi, pulse.pulse_length)
 end

--- a/src/pulse_profiles/generic.jl
+++ b/src/pulse_profiles/generic.jl
@@ -2,17 +2,22 @@
     return domain(pulse::AbstractPulseProfile)
 end
 
-function _internal_integrals(pulse::AbstractPulseProfile, pol::P, method::AbstractNumericalIntegrationMethod, phi::T) where {T <: Real, P <: AbstractDefinitePolarization}
+function _internal_integrals(pulse::AbstractPulseProfile, pol::P, method::AbstractNumericalIntegrationMethod, phi::T) where {T <: Number, P <: AbstractDefinitePolarization}
     tmp_func1 = t -> oscillator(pol, t) * _envelope(pulse, t)
     tmp_func2 = t -> (oscillator(pol, t) * _envelope(pulse, t))^2
 
     res1 = integrate(method, tmp_func1, zero(T), phi)
     res2 = integrate(method, tmp_func2, zero(T), phi)
-    return InternalIntegrals(res1, res2)
+
+    # TODO: put in the correct errors!
+    return InternalIntegrals(
+        InternalIntegralResult(res1, zero(res1)),
+        InternalIntegralResult(res2, zero(res1))
+    )
 end
 
 # FIXME: This is wrong! We need to insert the xi-dependent terms
-@inline function _internal_integrals(pulse::AbstractPulseProfile, pol::P, method::AbstractNumericalIntegrationMethod, phi::T) where {T <: Real, P <: AbstractIndefinitePolarization}
+@inline function _internal_integrals(pulse::AbstractPulseProfile, pol::P, method::AbstractNumericalIntegrationMethod, phi::T) where {T <: Number, P <: AbstractIndefinitePolarization}
     tmp_func11 = t -> oscillator(PolX(), phi) * _envelope(pulse, phi)
     tmp_func12 = t -> oscillator(PolY(), phi) * _envelope(pulse, phi)
 
@@ -31,7 +36,7 @@ end
 # domains, where simple quadrature does not work anymore, but needs to be replaced by the
 # actual value of the internal integral at the endpoint, e.g., by the integal from zero to
 # infinity.
-function internal_integrals(pulse::AbstractPulseProfile, pol::P, method::AbstractIntegrationMethod, phi::T)::InternalIntegrals{T} where {T <: Real, P <: AbstractPolarization}
+function internal_integrals(pulse::AbstractPulseProfile, pol::P, method::AbstractIntegrationMethod, phi::T)::InternalIntegrals{T} where {T <: Number, P <: AbstractPolarization}
 
     dom = compact_domain(pulse)
     phi_eval = phi <= infimum(dom) ? infimum(dom) : min(phi, supremum(dom))

--- a/src/pulse_profiles/interface.jl
+++ b/src/pulse_profiles/interface.jl
@@ -43,6 +43,6 @@ function _envelope end
 
 Return value of the envelope with bound-check.
 """
-function envelope(field::AbstractPulseProfile, phi::Real)
+function envelope(field::AbstractPulseProfile, phi::Number)
     return phi in domain(field) ? _envelope(field, phi) : zero(phi)
 end

--- a/src/pulsed_fields/generic.jl
+++ b/src/pulsed_fields/generic.jl
@@ -33,7 +33,7 @@ end
 
 # TODO: consider moving this to phase integrals and using the IntegralMethod interface
 
-@inline function _fourier_transform(func::Function, domain::Interval, l::Number)
+@inline function _fourier_transform(func::Function, domain::Interval, l::Real)
     return quadgk(t -> func(t) * exp(1im * t * l), endpoints(domain)...)[1]
 end
 
@@ -56,7 +56,7 @@ Return the generic spectrum of the given field, for the given polarization direc
     where ``g(\\phi)`` is the [`envelope`](@ref) and ``l`` the photon number parameter.
 """
 function generic_spectrum(
-        field::AbstractPulsedPlaneWaveField, pnum::Number
+        field::AbstractPulsedPlaneWaveField, pnum::Real
     )
     return _fourier_transform(t -> _amplitude(field, t), domain(field), pnum)
 end

--- a/src/pulsed_fields/generic.jl
+++ b/src/pulsed_fields/generic.jl
@@ -24,7 +24,7 @@ end
 
 # delegation of internal integrals to pulse profiles
 
-@inline function _internal_integrals(field::AbstractPulsedPlaneWaveField, method::AbstractIntegrationMethod, phi::Real)
+@inline function _internal_integrals(field::AbstractPulsedPlaneWaveField, method::AbstractIntegrationMethod, phi::Number)
     return _internal_integrals(pulse_profile(field), polarization(field), method, phi)
 end
 
@@ -33,7 +33,7 @@ end
 
 # TODO: consider moving this to phase integrals and using the IntegralMethod interface
 
-@inline function _fourier_transform(func::Function, domain::Interval, l::Real)
+@inline function _fourier_transform(func::Function, domain::Interval, l::Number)
     return quadgk(t -> func(t) * exp(1im * t * l), endpoints(domain)...)[1]
 end
 
@@ -56,7 +56,7 @@ Return the generic spectrum of the given field, for the given polarization direc
     where ``g(\\phi)`` is the [`envelope`](@ref) and ``l`` the photon number parameter.
 """
 function generic_spectrum(
-        field::AbstractPulsedPlaneWaveField, pnum::Real
+        field::AbstractPulsedPlaneWaveField, pnum::Number
     )
     return _fourier_transform(t -> _amplitude(field, t), domain(field), pnum)
 end

--- a/test/pulsed_fields/impl.jl
+++ b/test/pulsed_fields/impl.jl
@@ -9,6 +9,7 @@ using QEDbase
 using QEDcore
 using QEDfields
 using QuadGK
+using FCCQuad
 
 include("testutils.jl")
 
@@ -22,8 +23,10 @@ POLS = [PolX(), PolY()]
 A0 = rand(RNG)
 MOM = SFourMomentum(rand(RNG, 4))
 
+FCC_METHODS = (:plain, :tone, :chirp, :degree, :nonadaptive)
+
 INTERNAL_INTEGRATION_METHODS = (GaussLegendreQuadrature(1000),)
-PHASE_INTEGRATION_METHODS = (GaussKronrodQuadrature(),)
+PHASE_INTEGRATION_METHODS = (GaussKronrodQuadrature(), [FCCQuadrature(method = m) for m in FCC_METHODS]...)
 # TODO: enable this again, if endpoint internal integrals are introduced for infinite
 # domains
 #PHASE_INTEGRATION_METHODS= (GaussKronrodQuadrature(),GaussLegendreQuadrature(1000))

--- a/test/pulsed_fields/impl.jl
+++ b/test/pulsed_fields/impl.jl
@@ -9,7 +9,7 @@ using QEDbase
 using QEDcore
 using QEDfields
 using QuadGK
-using FCCQuad
+using FCCQuadrature
 
 include("testutils.jl")
 
@@ -26,7 +26,7 @@ MOM = SFourMomentum(rand(RNG, 4))
 FCC_METHODS = (:plain, :tone, :chirp, :degree, :nonadaptive)
 
 INTERNAL_INTEGRATION_METHODS = (GaussLegendreQuadrature(1000),)
-PHASE_INTEGRATION_METHODS = (GaussKronrodQuadrature(), [FCCQuadrature(method = m) for m in FCC_METHODS]...)
+PHASE_INTEGRATION_METHODS = (GaussKronrodQuadrature(), [FilonClenshawCurtisQuadrature(method = m) for m in FCC_METHODS]...)
 # TODO: enable this again, if endpoint internal integrals are introduced for infinite
 # domains
 #PHASE_INTEGRATION_METHODS= (GaussKronrodQuadrature(),GaussLegendreQuadrature(1000))

--- a/test/pulsed_fields/testutils.jl
+++ b/test/pulsed_fields/testutils.jl
@@ -9,7 +9,7 @@ function _groundtruth_phase_integrals(
     dom = compact_domain(field)
     max_amp = maximum_amplitude(field)
     function vphase(x)
-        ii = internal_integrals(field, internal_integral_method, x)
+        ii = QEDfields._internal_integrals(field, internal_integral_method, x)
         return max_amp * beta1 * ii.I1.value - max_amp^2 * beta2 * ii.I2.value
     end
 
@@ -23,5 +23,38 @@ function _groundtruth_phase_integrals(
     return PhaseIntegrals(
         PhaseIntegralResult(QEDfields._tuple_pack(res1)...),
         PhaseIntegralResult(QEDfields._tuple_pack(res2)...)
+    )
+end
+
+_as_vec(x::AbstractVector) = x
+_as_vec(x::Number) = [x]
+function _groundtruth_phase_integrals(
+        field::AbstractPlaneWaveField{P},
+        internal_integral_method::QEDfields.AbstractIntegrationMethod,
+        phase_integral_method::FCCQuadrature,
+        pnum::T,
+        beta1::T,
+        beta2::T
+    ) where {T, P}
+    dom = compact_domain(field)
+    max_amp = maximum_amplitude(field)
+
+    #=
+    function vphase(x)
+        ii = QEDfields._internal_integrals(field, internal_integral_method, x)
+        return max_amp * beta1 * ii.I1.value - max_amp^2 * beta2 * ii.I2.value
+    end
+    =#
+
+    osc = x -> exp(1im * QEDfields._volkov_phase(field, internal_integral_method, x, beta1, beta2))
+    pre1 = x -> max_amp * QEDfields._amplitude(field, x)
+    pre2 = x -> max_amp^2 * QEDfields._amplitude(field, x)^2
+
+    res1, nevals1 = fccquad(pre1, osc, _as_vec(pnum); xmin = minimum(dom), xmax = maximum(dom))
+    res2, nevals2 = fccquad(pre2, osc, _as_vec(pnum); xmin = minimum(dom), xmax = maximum(dom))
+
+    return PhaseIntegrals(
+        PhaseIntegralResult(QEDfields._tuple_pack(res1[:, 1])...),
+        PhaseIntegralResult(QEDfields._tuple_pack(res2[:, 1])...),
     )
 end

--- a/test/pulsed_fields/testutils.jl
+++ b/test/pulsed_fields/testutils.jl
@@ -31,7 +31,7 @@ _as_vec(x::Number) = [x]
 function _groundtruth_phase_integrals(
         field::AbstractPlaneWaveField{P},
         internal_integral_method::QEDfields.AbstractIntegrationMethod,
-        phase_integral_method::FCCQuadrature,
+        phase_integral_method::FilonClenshawCurtisQuadrature,
         pnum::T,
         beta1::T,
         beta2::T


### PR DESCRIPTION
Adds [`FCCQuadrature.jl`](https://github.com/dkm2/FCCQuadrature.jl) as an integration method for pulsed planewave fields. 

~Since `FCCQuad.jl` is not registered yet, the repo source is added to the Project.toml directly. See [here](https://github.com/dkm2/FCCQuad.jl/pull/2) for the progress of the registration of `FCCQuad.jl`.~


## TODOs

- [x] docs
- [ ] ~indefinite polarization~
